### PR TITLE
Progressive output and cancel button for 'Inference' tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -195,6 +195,7 @@ class UI():
                 )
 
                 self.generate_btn = gr.Button('Generate', variant='primary')
+                self.cancel_btn = gr.Button('Cancel', variant='primary')
 
                 with gr.Row():
                     with gr.Column():
@@ -284,8 +285,11 @@ class UI():
                 #Do a bunch of stuff here
                 max_length = max_new_tokens
                 max_new_tokens = 1
+                self.cancel_request = False
                 
                 for i in range(max_length):
+                    if self.cancel_request:
+                        break
                     this_output = self.trainer.generate(
                         prompt,
                         do_sample=do_sample,
@@ -300,10 +304,9 @@ class UI():
                         break
                     prompt = this_output
                     yield this_output
-                
-                
+                    
             
-            self.generate_btn.click(
+            generate_event = self.generate_btn.click(
                 fn=generate_async,
                 inputs=[
                     self.prompt,
@@ -317,6 +320,13 @@ class UI():
                 ],
                 outputs=[self.output]
             )
+
+
+            def cancel_clicked():
+                self.cancel_request = True
+            
+            
+            self.cancel_btn.click(fn=None, inputs=None, outputs=None, cancels=[generate_event])
 
     def layout(self):
         with gr.Blocks() as demo:

--- a/app.py
+++ b/app.py
@@ -270,8 +270,41 @@ class UI():
                     top_k=top_k
                 )
             
+            def generate_async(
+                prompt,
+                do_sample,
+                max_new_tokens,
+                num_beams,
+                repeat_penalty,
+                temperature,
+                top_p,
+                top_k,
+                progress=gr.Progress(track_tqdm=True)
+            ):
+                #Do a bunch of stuff here
+                max_length = max_new_tokens
+                max_new_tokens = 1
+                
+                for i in range(max_length):
+                    this_output = self.trainer.generate(
+                        prompt,
+                        do_sample=do_sample,
+                        max_new_tokens=max_new_tokens,
+                        num_beams=num_beams,
+                        repetition_penalty=repeat_penalty,
+                        temperature=temperature,
+                        top_p=top_p,
+                        top_k=top_k
+                    )
+                    if len(prompt) == len(this_output):
+                        break
+                    prompt = this_output
+                    yield this_output
+                
+                
+            
             self.generate_btn.click(
-                fn=generate,
+                fn=generate_async,
                 inputs=[
                     self.prompt,
                     self.do_sample,


### PR DESCRIPTION
I have added progressive output to the inference tab by converting the `generate` function in app.py to a Python generator and producing tokens one at at time until either the output remains the same (end of stream reached) or the max tokens have been generated.