### PR TITLE
Resolve Error: Adapter lora/{MODE_NAME}-{ADAPTER_NAME} not found.

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -47,6 +47,8 @@ class Trainer():
             load_in_8bit=True,
             torch_dtype=torch.float16,
         )
+        #Clear the collection that tracks which adapters are loaded, as they are associated with self.model
+        self.loras = {}
 
         if model_name.startswith('decapoda-research/llama'):
             self.tokenizer = transformers.LlamaTokenizer.from_pretrained(model_name)
@@ -74,7 +76,6 @@ class Trainer():
         
         if peft_config.base_model_name_or_path != self.model_name:
             self.load_model(peft_config.base_model_name_or_path)
-            self.loras = {}
 
         assert self.model_name is not None
         assert self.model is not None


### PR DESCRIPTION
resolves #44 

The issue itself contains the documentation of the issue and it's reproduction steps.

The problem seems to be with the `self.loras` collection that is used to keep track of which adapters have been loaded to avoid re-loading then when switching back and forth.

However, they are only cleared somewhere in the training code, and in the method that is invoked when the LoRA dropdown is switched. Changing models does not clear the collection, causing the above bug due to trying to call `set_adapter` on a model instance that has not had `load_adapter` called for it.

I have resolved this by clearing the collection every time the model is changed in `self.load_model` so that it reflects the state of the currently loaded model.